### PR TITLE
Fix upper bound not being used in var! macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rplex"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["J David Smith <emallson@atlanis.net>"]
 build = "build.rs"
 links = "static=cplex"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -331,13 +331,13 @@ macro_rules! var {
     ($lb:tt <= $name:tt <= $ub:tt -> $obj:tt) => (var!($lb <= $name <= $ub -> $obj as Continuous));
     // omit either lb or ub
     ($lb:tt <= $name:tt -> $obj:tt) => (var!($lb <= $name <= INFINITY -> $obj));
-    ($name:tt <= $ub:tt -> $obj:tt) => (var!(0.0 <= $name <= INFINITY -> $obj));
+    ($name:tt <= $ub:tt -> $obj:tt) => (var!(0.0 <= $name <= $ub -> $obj));
     // omit both
     ($name:tt -> $obj:tt) => (var!(0.0 <= $name -> $obj));
 
     // typed version
     ($lb:tt <= $name:tt -> $obj:tt as $vt:path) => (var!($lb <= $name <= INFINITY -> $obj as $vt));
-    ($name:tt <= $ub:tt -> $obj:tt as $vt:path) => (var!(0.0 <= $name <= INFINITY -> $obj as $vt));
+    ($name:tt <= $ub:tt -> $obj:tt as $vt:path) => (var!(0.0 <= $name <= $ub -> $obj as $vt));
     ($name:tt -> $obj:tt as Binary) => (var!(0.0 <= $name <= 1.0 -> $obj as Binary));
     ($name:tt -> $obj:tt as $vt:path) => (var!(0.0 <= $name -> $obj as $vt));
 }


### PR DESCRIPTION
See issue #1 

In two places in the var! macro, the upper bound was left out if there was no accompanying lower bound.